### PR TITLE
Restores goal speed, excluding hoops and dropshot

### DIFF
--- a/GoalSpeedAnywhere/GoalSpeedAnywhere.cpp
+++ b/GoalSpeedAnywhere/GoalSpeedAnywhere.cpp
@@ -31,7 +31,6 @@ void GoalSpeedAnywhere::onUnload() {}
 
 void GoalSpeedAnywhere::ShowSpeed()
 {
-	cvarManager->log("Function triggered");
 	if(!(*bEnabled)) return;
 	bShowSpeed = true;
 

--- a/GoalSpeedAnywhere/GoalSpeedAnywhere.cpp
+++ b/GoalSpeedAnywhere/GoalSpeedAnywhere.cpp
@@ -23,6 +23,8 @@ void GoalSpeedAnywhere::onLoad()
 	cvarManager->registerCvar("GSA_Decimal_Precision", "2", "Goal speed anywhere decimal places to display", true, true, 0, true, 6).bindTo(DecimalPrecision);
 	cvarManager->registerCvar("GSA_Color", "(0, 255, 0, 255)", "Goal speed anywhere text color", true).bindTo(TextColor);
 
+	gameWrapper->HookEvent("Function TAGame.Ball_TA.OnHitGoal", std::bind(&GoalSpeedAnywhere::ShowSpeed, this));
+	gameWrapper->HookEvent("Function TAGame.Ball_TA.Explode", std::bind(&GoalSpeedAnywhere::ShowSpeed, this));
 	gameWrapper->HookEvent("Function Engine.GameViewportClient.Tick", std::bind(&GoalSpeedAnywhere::GetSpeed, this));
 	
 	gameWrapper->RegisterDrawable(bind(&GoalSpeedAnywhere::Render, this, std::placeholders::_1));
@@ -56,21 +58,22 @@ void GoalSpeedAnywhere::GetSpeed()
 
 	Speed = ball.GetVelocity().magnitude();
 
+	auto ballRadius = ball.GetRadius();
+
 	ArrayWrapper<GoalWrapper> goalWrappers = server.GetGoals();
 	for(auto goalWrapper : goalWrappers)
 	{
 		auto location = goalWrapper.GetLocation();
-		if(!ballIsInsideGoal && abs(ball.GetLocation().Y) >= abs(location.Y))
+		if(!ballIsInsideGoal && abs(ball.GetLocation().Y) >= (abs(location.Y) + ballRadius) )
 		{
 			ballIsInsideGoal = true;
 			ShowSpeed();
 		}
-		else if(ballIsInsideGoal && abs(ball.GetLocation().Y) < abs(location.Y))
+		else if(ballIsInsideGoal && abs(ball.GetLocation().Y) < (abs(location.Y) + ballRadius))
 		{
 			ballIsInsideGoal = false;
 		}
 	}
-		
 }
 
 void GoalSpeedAnywhere::Render(CanvasWrapper canvas)

--- a/GoalSpeedAnywhere/GoalSpeedAnywhere.cpp
+++ b/GoalSpeedAnywhere/GoalSpeedAnywhere.cpp
@@ -2,6 +2,7 @@
 #include "bakkesmod\wrappers\includes.h"
 #include <sstream>
 #include <iomanip>
+#include <unordered_set>
 
 BAKKESMOD_PLUGIN(GoalSpeedAnywhere, "Show the goal speed in any game mode", "1.1", PLUGINTYPE_FREEPLAY)
 
@@ -51,7 +52,10 @@ void GoalSpeedAnywhere::GetSpeed()
 	if(server.IsNull()) return;
 	GameSettingPlaylistWrapper playlist = server.GetPlaylist();
 	if(playlist.IsNull()) return;
-	if(playlist.GetPlaylistId() == 17 || playlist.GetPlaylistId() == 23) return; // We currently don't support Hoops or Drop Shot
+
+	// Exclude some game modes where goals are not always outside of arena bounds, or horizontal
+	static const std::unordered_set<int> excludedPlaylistIds = { 15, 17, 18, 19, 23 }; // Snow Day, Hoops, Rumble, Workshop, Dropshot
+	if(excludedPlaylistIds.count(playlist.GetPlaylistId()) > 0) return;
 
 	BallWrapper ball = server.GetBall();
 	if(ball.IsNull()) return;

--- a/GoalSpeedAnywhere/GoalSpeedAnywhere.h
+++ b/GoalSpeedAnywhere/GoalSpeedAnywhere.h
@@ -15,6 +15,7 @@ private:
 
 	bool bShowSpeed = false;
 	float Speed = 0;
+	bool ballIsInsideGoal = false;
 
 public:
 	void onLoad() override;


### PR DESCRIPTION
Proposed fix for issue #2 

How it works:
- We retrieve the Y coordinate for every goal on the map. As soon as the ball transitions beyond that value (in absolute coordinates), we switch a bool flag to remember the ball is in the goal, and display the goal speed. Afterwards, we ignore any further event until the ball is no longer in the goal (the way it gets out of there is not relevant, luckily)
- Unfortunately, this does not work for drop shot or hoops. We could make it work for drop shot by doing the same with the Z coordinate probably, but it would be a lot more complicated for hoops (round goal, hovering over the playing field)

Performed tests:
- Does not trigger anything in hoops
- Does not trigger anything in dropshot
- Does not influence custom workshop maps which don't have goals
- Works with goal scoring enabled
- Works with goal scoring disabled
- Works in free play
- Works in custom training
- Works in snow day
- Works in casual
- Works when changing map while the ball is in the goal

Potential issues:
- The range-based for loop causes warning C4267 (size_t to int conversion). If you want, you can disable the warning or figure out a different loop which does not trigger it
- Currently, the check for a goal/non-goal happens on every tick. I can still get 240fps with this so it seems quick enough. If this bother you, you might want to find a different event to hook to, which triggers not as often, but still often enough
