### PR TITLE
Improves the workaround of the previous pull request

### DIFF
--- a/GoalSpeedAnywhere/GoalSpeedAnywhere.cpp
+++ b/GoalSpeedAnywhere/GoalSpeedAnywhere.cpp
@@ -45,6 +45,8 @@ void GoalSpeedAnywhere::onUnload() {}
 void GoalSpeedAnywhere::ShowSpeed()
 {
 	if(!(*bEnabled)) return;
+	if (Speed < FLT_EPSILON) return; // A goal speed of zero most likely wasn't a goal, but an event sent during goal replay or something.
+
 	bShowSpeed = true;
 
 	gameWrapper->SetTimeout(std::bind(&GoalSpeedAnywhere::HideSpeed, this), *Duration);

--- a/GoalSpeedAnywhere/GoalSpeedAnywhere.h
+++ b/GoalSpeedAnywhere/GoalSpeedAnywhere.h
@@ -12,6 +12,7 @@ private:
 	std::shared_ptr<int> YPos;
 	std::shared_ptr<int> DecimalPrecision;
     std::shared_ptr<LinearColor> TextColor;
+	std::shared_ptr<bool> bGoalScoringIsEnabled;
 
 	bool bShowSpeed = false;
 	float Speed = 0;


### PR DESCRIPTION
Commit 1 now only executes the workaround when the player is in fact in free play and has goal scoring turned off. Additionally, it does the check for the game mode later so the regular extra mode matches, where goal scoring is always turned on, are now supported again (The previous PR removed support from them by accident)

Commit 2 makes it so that a goal speed is no longer shown at the end of the match, or when the timer runs out in custom training