### PR TITLE
Fixes goal speed for Epic Season 6 Update

### DIFF
--- a/GoalSpeedAnywhere/GoalSpeedAnywhere.cpp
+++ b/GoalSpeedAnywhere/GoalSpeedAnywhere.cpp
@@ -71,7 +71,7 @@ void GoalSpeedAnywhere::GetSpeed()
 	BallWrapper ball = server.GetBall();
 	if(ball.IsNull()) return;
 
-	Speed = ball.GetVelocity().magnitude();
+	Speed = ball.GetCurrentRBState().LinearVelocity.magnitude();
 
 	// The following code is only required for cases where OnHitGoal and Explode events are not sent
 	// Currently this can only happen in freeplay with goal scoring turned off in Bakkesmod.


### PR DESCRIPTION
An anti-cheat randomization Bakkes added apparently broke `ball.GetVelocity()` with today's update, producing random goal speeds (up to infinite) when playing online matches.
Bakkes suggested using `.GetCurrentRBState().LinearVelocity` instead of `.GetVelocity()`, which in fact fixes it.